### PR TITLE
chore: Using Yontrack 5.0.5

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.17
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.4"
+appVersion: "5.0.5"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.4](https://ontrack.nemerosa.net/build/10880) to [5.0.5](https://ontrack.nemerosa.net/build/10893)

* [#1518](https://github.com/nemerosa/ontrack/issues/1518) Link nodes in branch dependency graphs must have colour/clear indicators about their status
* [#1519](https://github.com/nemerosa/ontrack/issues/1519) Restore displaying & filtering the queue in the auto-versioning audit page
* [#1520](https://github.com/nemerosa/ontrack/issues/1520) Missing volume & settings for working data in the Yontrack Docker image
