### PR TITLE
chore: Using Yontrack 5.0.16

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.22
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.15"
+appVersion: "5.0.16"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.15](https://ontrack.nemerosa.net/build/10945) to [5.0.16](https://ontrack.nemerosa.net/build/10949)

* [#1533](https://github.com/nemerosa/ontrack/issues/1533) A deployment must be marked as failed (error) if one of its workflows fails
