### PR TITLE
chore: Using Yontrack 5.0.21

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.22
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.20"
+appVersion: "5.0.21"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.20](https://ontrack.nemerosa.net/build/10963) to [5.0.21](https://ontrack.nemerosa.net/build/10967)

* [#1543](https://github.com/nemerosa/ontrack/issues/1543) In some cases, downstream dependency checks are mixed up
