### PR TITLE
chore: Using Yontrack 5.0.23

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.23
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.22"
+appVersion: "5.0.23"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.22](https://ontrack.nemerosa.net/build/10971) to [5.0.23](https://ontrack.nemerosa.net/build/10978)

* [#1539](https://github.com/nemerosa/ontrack/issues/1539) When focusing on a branch node, expand to include the branch nodes beyond the links
* [#1541](https://github.com/nemerosa/ontrack/issues/1541) Filter on dependencies in the downstream & upstream views in the build page
* [#1542](https://github.com/nemerosa/ontrack/issues/1542) In the list of AV targets in a promotion or promotion run, filter on eligibility and target project
* [#1544](https://github.com/nemerosa/ontrack/issues/1544) Icon to navigate to the build links in a build node in the build links graph
* [#1545](https://github.com/nemerosa/ontrack/issues/1545) Previous/next builds don't navigate to the page
