### PR TITLE
chore: Using Yontrack 5.0.24

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.23
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.23"
+appVersion: "5.0.24"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.23](https://ontrack.nemerosa.net/build/10978) to [5.0.24](https://ontrack.nemerosa.net/build/10982)

* [#1538](https://github.com/nemerosa/ontrack/issues/1538) In the branch links, add a changelog button when the build is not the latest
* [#1542](https://github.com/nemerosa/ontrack/issues/1542) In the list of AV targets in a promotion or promotion run, filter on eligibility and target project
* [#1548](https://github.com/nemerosa/ontrack/issues/1548) Missing filter on the branch for the AV extension in the CI config
