### PR TITLE
chore: Using Yontrack 5.0.25

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.23
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.24"
+appVersion: "5.0.25"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.24](https://ontrack.nemerosa.net/build/10982) to [5.0.25](https://ontrack.nemerosa.net/build/10985)

* [#1538](https://github.com/nemerosa/ontrack/issues/1538) In the branch links, add a changelog button when the build is not the latest
* [#1549](https://github.com/nemerosa/ontrack/issues/1549) Some LDAP group names can be longer than 64 characters
