### PR TITLE
chore: Using Yontrack 5.0.26

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.25
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.25"
+appVersion: "5.0.26"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.25](https://ontrack.nemerosa.net/build/10985) to [5.0.26](https://ontrack.nemerosa.net/build/10999)

* [#1550](https://github.com/nemerosa/ontrack/issues/1550) AV cron schedule is not displayed correctly
