### PR TITLE
chore: Using Yontrack 5.0.28

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.27
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.27"
+appVersion: "5.0.28"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.27](https://ontrack.nemerosa.net/build/11015) to [5.0.28](https://ontrack.nemerosa.net/build/11024)

* [#1560](https://github.com/nemerosa/ontrack/issues/1560) Restore getting the issue service identifier from an environment variable
