### PR TITLE
chore: Using Yontrack 5.0.40

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.36
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.39"
+appVersion: "5.0.40"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://ontrack.nemerosa.net/project/1) from [5.0.39](https://ontrack.nemerosa.net/build/11120) to [5.0.40](https://ontrack.nemerosa.net/build/11125)

* [#1584](https://github.com/nemerosa/ontrack/issues/1584) Add support for NEXTAUTH_ISSUER_INTERNAL for in-cluster Keycloak setups
