### PR TITLE
chore: Using Yontrack 5.0.41

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.41
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.40"
+appVersion: "5.0.41"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://self.dev.yontrack.com/project/1) from [5.0.40](https://self.dev.yontrack.com/build/11125) to [5.0.41](https://self.dev.yontrack.com/build/11133)

* [#1587](https://github.com/nemerosa/ontrack/issues/1587) Global function 'NotificationRecordingAccess' is required for Yontrack promotion notification
