### PR TITLE
chore: Using Yontrack 5.0.42

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.41
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.41"
+appVersion: "5.0.42"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://self.dev.yontrack.com/project/1) from [5.0.41](https://self.dev.yontrack.com/build/11133) to [5.0.42](https://self.dev.yontrack.com/build/11136)

* [#1568](https://github.com/nemerosa/ontrack/issues/1568) Scheduled auto-versioning request stays in Created (running) state
* [#1577](https://github.com/nemerosa/ontrack/issues/1577) The Yontrack Promotion notification must normalize the target branch name
* [#1589](https://github.com/nemerosa/ontrack/pull/1589) [Claude] #1577: Normalize branch name in Yontrack Promotion notification
* [#1590](https://github.com/nemerosa/ontrack/pull/1590) [Claude] #1568: Scheduled AV request shows PENDING_SCHEDULE state immediately
