### PR TITLE
chore: Using Yontrack 5.0.43

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.41
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.42"
+appVersion: "5.0.43"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://self.dev.yontrack.com/project/1) from [5.0.42](https://self.dev.yontrack.com/build/11136) to [5.0.43](https://self.dev.yontrack.com/build/11140)

* [#1591](https://github.com/nemerosa/ontrack/issues/1591) Missing display for the "promotion dependencies" property
* [#1593](https://github.com/nemerosa/ontrack/issues/1593) Auto-disabling of branches issue
* [#1594](https://github.com/nemerosa/ontrack/issues/1594) Configuration of the "auto-disabling branches" property at project level
