### PR TITLE
chore: Using Yontrack 5.0.44

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.41
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.43"
+appVersion: "5.0.44"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://self.dev.yontrack.com/project/1) from [5.0.43](https://self.dev.yontrack.com/build/11140) to [5.0.44](https://self.dev.yontrack.com/build/11159)

* [#1596](https://github.com/nemerosa/ontrack/issues/1596) Cannot set the `auto-disabling` property on a project using the CI config when not admin
