### PR TITLE
chore: Using Yontrack 5.0.46

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.41
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.45"
+appVersion: "5.0.46"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://self.dev.yontrack.com/project/1) from [5.0.45](https://self.dev.yontrack.com/build/11164) to [5.0.46](https://self.dev.yontrack.com/build/11168)

* [#1599](https://github.com/nemerosa/ontrack/issues/1599) Missing GH AV Post Processing Display UI
* [#1600](https://github.com/nemerosa/ontrack/issues/1600) GraphQL mutation to delete build links
