### PR TITLE
chore: Using Yontrack 5.1.0

### DIFF
--- a/charts/ontrack/Chart.yaml
+++ b/charts/ontrack/Chart.yaml
@@ -20,7 +20,7 @@ version: 5.0.41
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.46"
+appVersion: "5.1.0"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Change log for [ontrack](https://self.dev.yontrack.com/project/1) from [5.0.46](https://self.dev.yontrack.com/build/11168) to [5.1.0](https://self.dev.yontrack.com/build/11185)

* [#1418](https://github.com/nemerosa/ontrack/issues/1418) [next-ui] Management of validation stamps
* [#1472](https://github.com/nemerosa/ontrack/issues/1472) Auto-versioning config inline documentation & JSON schema
* [#1567](https://github.com/nemerosa/ontrack/issues/1567) Improve auto-versioning audit page layout
* [#1602](https://github.com/nemerosa/ontrack/issues/1602) Auto-versioning mode to push directly to the target branch
* [#1603](https://github.com/nemerosa/ontrack/issues/1603) Regression in workflows about the NotificationRecordingAccess permission
* [#1604](https://github.com/nemerosa/ontrack/issues/1604) The outcome of the Yontrack promotion notification is not displayed immediately
